### PR TITLE
[FEAT] Add microservices ingress routing and OAuth2 support - PIT-194

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# SSL files directory
+ssl_files/
+

--- a/argocd.tf
+++ b/argocd.tf
@@ -66,6 +66,10 @@ resource "helm_release" "argocd" {
           "admin.enabled" = "true"
           "admin.password" = var.argocd_admin_password
           "admin.passwordMtime" = "2024-01-01T00:00:00Z"
+          # Base path 설정 - 모든 정적 리소스가 /argo로 시작하도록
+          "url" = "https://${var.ssl_domain_name}/argo"
+          "server.rootpath" = "/argo"
+          "server.basehref" = "/argo"
         }
         
         # 리소스 제한 (CPU 부족 문제 해결을 위한 증가)

--- a/ingress.tf
+++ b/ingress.tf
@@ -1,6 +1,16 @@
 # Nginx Ingress Controller 배포
 # Private Cluster에서 외부 접근을 위한 Ingress Controller
 
+# =============================================================================
+# SSL/TLS 인증서 설정 (GCP에서 직접 업로드한 인증서 참조)
+# =============================================================================
+
+# GCP에서 직접 업로드한 SSL 인증서 참조 (Compute Engine SSL 인증서)
+data "google_compute_ssl_certificate" "existing_cert" {
+  count = var.ssl_enabled && var.ssl_certificate_name != "" ? 1 : 0
+  name  = var.ssl_certificate_name
+}
+
 # Nginx Ingress Controller 네임스페이스
 resource "kubernetes_namespace" "ingress_nginx" {
   count = var.ingress_nginx_enabled ? 1 : 0
@@ -63,9 +73,15 @@ resource "helm_release" "ingress_nginx" {
         service = {
           type = "LoadBalancer"
           loadBalancerIP = google_compute_address.ingress_ip[0].address
-          annotations = {
-            "cloud.google.com/load-balancer-type" = "External"
-          }
+          annotations = merge(
+            {
+              "cloud.google.com/load-balancer-type" = "External"
+            },
+            var.ssl_enabled && var.ssl_certificate_name != "" ? {
+              "cloud.google.com/load-balancer-ssl-certificates" = data.google_compute_ssl_certificate.existing_cert[0].name
+              "cloud.google.com/load-balancer-backend-protocol" = "HTTP"
+            } : {}
+          )
         }
         
         # 리소스 제한 (CPU 부족 문제 해결을 위한 증가)
@@ -120,5 +136,55 @@ resource "helm_release" "ingress_nginx" {
     google_container_cluster.primary,
     google_container_node_pool.primary_nodes,
     time_sleep.wait_for_nodes
+  ]
+}
+
+# API 서비스용 Ingress (표준 헬스체크 경로 사용)
+resource "kubernetes_ingress_v1" "api_ingress" {
+  count = var.ingress_nginx_enabled ? 1 : 0
+
+  metadata {
+    name      = "api-ingress"
+    namespace = "default"
+    annotations = {
+      "kubernetes.io/ingress.class"                = "nginx"
+      "nginx.ingress.kubernetes.io/rewrite-target" = "/"
+    }
+  }
+
+  spec {
+    rule {
+      host = var.ssl_domain_name
+      http {
+        path {
+          path      = "/health"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "api-service"
+              port {
+                number = 80
+              }
+            }
+          }
+        }
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "api-service"
+              port {
+                number = 80
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.ingress_nginx
   ]
 }

--- a/ingress.tf
+++ b/ingress.tf
@@ -139,43 +139,159 @@ resource "helm_release" "ingress_nginx" {
   ]
 }
 
-# API 서비스용 Ingress (표준 헬스체크 경로 사용)
-resource "kubernetes_ingress_v1" "api_ingress" {
+# =============================================================================
+# 네임스페이스 관리
+# =============================================================================
+
+# loventure-app 네임스페이스는 ArgoCD에서 생성됨
+# Terraform에서는 Ingress 리소스만 관리
+
+# =============================================================================
+# ExternalName 서비스 정의
+# 각 네임스페이스의 서비스에 접근하기 위한 ExternalName 서비스들
+# =============================================================================
+
+# ArgoCD 서버용 ExternalName 서비스 (argocd 네임스페이스)
+resource "kubernetes_service" "argocd_server_external" {
   count = var.ingress_nginx_enabled ? 1 : 0
 
   metadata {
-    name      = "api-ingress"
-    namespace = "default"
+    name      = "argocd-server-external"
+    namespace = var.argocd_namespace
+  }
+  
+  spec {
+    type          = "ExternalName"
+    external_name = "argocd-server.argocd.svc.cluster.local"
+  }
+}
+
+# ExternalName 서비스들은 동일 네임스페이스 내에서 불필요하므로 제거
+# 직접 서비스명을 사용하여 성능 향상 및 설정 단순화
+
+# Gateway 서비스용 ExternalName 서비스 (loventure-app 네임스페이스) - 주석처리
+# resource "kubernetes_service" "gateway_external" {
+#   count = var.ingress_nginx_enabled ? 1 : 0
+
+#   metadata {
+#     name      = "gateway-external"
+#     namespace = "loventure-app"
+#   }
+  
+#   spec {
+#     type          = "ExternalName"
+#     external_name = "loventure-prod-gateway-lb.loventure-app.svc.cluster.local"
+#   }
+# }
+
+# =============================================================================
+# Auth Service 전용 Ingress (api.loventure.us)
+# -----------------------------------------------------------------------------
+# Auth Service API 엔드포인트를 위한 전용 Ingress
+resource "kubernetes_ingress_v1" "auth_service_ingress" {
+  count = var.ingress_nginx_enabled ? 1 : 0
+
+  metadata {
+    name      = "auth-service-ingress"
+    namespace = "loventure-app"
     annotations = {
-      "kubernetes.io/ingress.class"                = "nginx"
-      "nginx.ingress.kubernetes.io/rewrite-target" = "/"
+      "nginx.ingress.kubernetes.io/use-regex"      = "true"
+      "nginx.ingress.kubernetes.io/ssl-redirect"   = "true"
+      "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true"
+      "nginx.ingress.kubernetes.io/proxy-body-size" = "10m"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout" = "300"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout" = "300"
     }
   }
 
   spec {
+    # Ingress Class 설정
+    ingress_class_name = "nginx"
+    
+    # SSL/TLS 설정
+    tls {
+      hosts = [var.ssl_domain_name]
+      secret_name = var.ssl_enabled && var.ssl_certificate_name != "" ? data.google_compute_ssl_certificate.existing_cert[0].name : null
+    }
+
+    # Auth Service API 규칙
     rule {
       host = var.ssl_domain_name
       http {
+        # OAuth2 Authorization 엔드포인트들
+        path {
+          path      = "/oauth2"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-auth-service"
+              port {
+                number = 8081
+              }
+            }
+          }
+        }
+        # Auth Service API 경로들
+        path {
+          path      = "/api/auth"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-auth-service"
+              port {
+                number = 8081
+              }
+            }
+          }
+        }
+        # Onboarding API 경로
+        path {
+          path      = "/api/onboarding"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-auth-service"
+              port {
+                number = 8081
+              }
+            }
+          }
+        }
+        # User Management API 경로
+        path {
+          path      = "/api/users"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-auth-service"
+              port {
+                number = 8081
+              }
+            }
+          }
+        }
+        # Health check 경로
         path {
           path      = "/health"
           path_type = "Prefix"
           backend {
             service {
-              name = "api-service"
+              name = "loventure-prod-auth-service"
               port {
-                number = 80
+                number = 8081
               }
             }
           }
         }
+        # Spring Boot Actuator health check 경로
         path {
-          path      = "/"
+          path      = "/actuator"
           path_type = "Prefix"
           backend {
             service {
-              name = "api-service"
+              name = "loventure-prod-auth-service"
               port {
-                number = 80
+                number = 8081
               }
             }
           }
@@ -188,3 +304,222 @@ resource "kubernetes_ingress_v1" "api_ingress" {
     helm_release.ingress_nginx
   ]
 }
+
+# =============================================================================
+# Course Service 전용 Ingress (api.loventure.us)
+# -----------------------------------------------------------------------------
+# Course Service API 엔드포인트를 위한 전용 Ingress
+resource "kubernetes_ingress_v1" "course_service_ingress" {
+  count = var.ingress_nginx_enabled ? 1 : 0
+
+  metadata {
+    name      = "course-service-ingress"
+    namespace = "loventure-app"
+    annotations = {
+      "nginx.ingress.kubernetes.io/use-regex"      = "true"
+      "nginx.ingress.kubernetes.io/ssl-redirect"   = "true"
+      "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true"
+      "nginx.ingress.kubernetes.io/proxy-body-size" = "10m"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout" = "300"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout" = "300"
+    }
+  }
+
+  spec {
+    # Ingress Class 설정
+    ingress_class_name = "nginx"
+    
+    # SSL/TLS 설정
+    tls {
+      hosts = [var.ssl_domain_name]
+      secret_name = var.ssl_enabled && var.ssl_certificate_name != "" ? data.google_compute_ssl_certificate.existing_cert[0].name : null
+    }
+
+    # Course Service API 규칙
+    rule {
+      host = var.ssl_domain_name
+      http {
+        # Course API 경로들
+        path {
+          path      = "/api/course"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-course-service"
+              port {
+                number = 8083
+              }
+            }
+          }
+        }
+        # Course Health check 경로
+        path {
+          path      = "/api/course/health"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-course-service"
+              port {
+                number = 8083
+              }
+            }
+          }
+        }
+        # Course Actuator 경로
+        path {
+          path      = "/api/course/actuator"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-course-service"
+              port {
+                number = 8083
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.ingress_nginx
+  ]
+}
+
+# =============================================================================
+# Content Service 전용 Ingress (api.loventure.us)
+# -----------------------------------------------------------------------------
+# Content Service API 엔드포인트를 위한 전용 Ingress
+resource "kubernetes_ingress_v1" "content_service_ingress" {
+  count = var.ingress_nginx_enabled ? 1 : 0
+
+  metadata {
+    name      = "content-service-ingress"
+    namespace = "loventure-app"
+    annotations = {
+      "nginx.ingress.kubernetes.io/use-regex"      = "true"
+      "nginx.ingress.kubernetes.io/ssl-redirect"   = "true"
+      "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true"
+      "nginx.ingress.kubernetes.io/proxy-body-size" = "10m"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout" = "300"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout" = "300"
+    }
+  }
+
+  spec {
+    # Ingress Class 설정
+    ingress_class_name = "nginx"
+    
+    # SSL/TLS 설정
+    tls {
+      hosts = [var.ssl_domain_name]
+      secret_name = var.ssl_enabled && var.ssl_certificate_name != "" ? data.google_compute_ssl_certificate.existing_cert[0].name : null
+    }
+
+    # Content Service API 규칙
+    rule {
+      host = var.ssl_domain_name
+      http {
+        # Diaries API 경로들
+        path {
+          path      = "/api/diaries"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-content-service"
+              port {
+                number = 8082
+              }
+            }
+          }
+        }
+        # Content Health check 경로
+        path {
+          path      = "/api/diaries/health"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-content-service"
+              port {
+                number = 8082
+              }
+            }
+          }
+        }
+        # Content Actuator 경로
+        path {
+          path      = "/api/diaries/actuator"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-content-service"
+              port {
+                number = 8082
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.ingress_nginx
+  ]
+}
+
+# =============================================================================
+# ArgoCD 전용 Ingress (argocd 네임스페이스)
+# -----------------------------------------------------------------------------
+# ArgoCD 서버 접근을 위한 전용 Ingress
+resource "kubernetes_ingress_v1" "argocd_ingress" {
+  count = var.ingress_nginx_enabled ? 1 : 0
+
+  metadata {
+    name      = "argocd-ingress"
+    namespace = var.argocd_namespace
+    annotations = {
+      "nginx.ingress.kubernetes.io/ssl-redirect"   = "true"
+      "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true"
+      "nginx.ingress.kubernetes.io/backend-protocol" = "HTTP"
+    }
+  }
+
+  spec {
+    # Ingress Class 설정
+    ingress_class_name = "nginx"
+    
+    # SSL/TLS 설정
+    tls {
+      hosts = ["argo.loventure.us"]
+      secret_name = var.ssl_enabled && var.ssl_certificate_name != "" ? data.google_compute_ssl_certificate.existing_cert[0].name : null
+    }
+
+    # ArgoCD 서버 규칙
+    rule {
+      host = "argo.loventure.us"
+      http {
+        # 모든 경로 -> ArgoCD 서버
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "argocd-server"
+              port {
+                number = 80
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.ingress_nginx,
+    helm_release.argocd
+  ]
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -163,3 +163,32 @@ output "ingress_nginx_status_command" {
   description = "Nginx Ingress Controller 상태 확인 명령어"
   value       = var.ingress_nginx_enabled ? "kubectl get pods -n ingress-nginx" : null
 }
+
+# =============================================================================
+# SSL/TLS 인증서 출력값
+# =============================================================================
+output "ssl_enabled" {
+  description = "SSL/TLS 인증서 사용 여부"
+  value       = var.ssl_enabled
+}
+
+output "ssl_domain_name" {
+  description = "SSL 인증서가 적용된 도메인 이름"
+  value       = var.ssl_enabled ? var.ssl_domain_name : null
+}
+
+output "ssl_certificate_name" {
+  description = "Google Cloud SSL 인증서 이름"
+  value       = var.ssl_enabled && var.ssl_certificate_name != "" ? data.google_compute_ssl_certificate.existing_cert[0].name : null
+}
+
+output "ssl_certificate_status_command" {
+  description = "SSL 인증서 상태 확인 명령어"
+  value       = var.ssl_enabled && var.ssl_certificate_name != "" ? "gcloud compute ssl-certificates describe ${data.google_compute_ssl_certificate.existing_cert[0].name} --global" : null
+}
+
+
+output "ssl_https_url" {
+  description = "HTTPS 접속 URL"
+  value       = var.ssl_enabled ? "https://${var.ssl_domain_name}" : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -124,19 +124,19 @@ variable "node_pool_name" {
 variable "node_count" {
   type        = number
   description = "초기 노드 수 (자동 스케일링으로 변경됨)"
-  default     = 2
+  default     = 4
 }
 
 variable "min_node_count" {
   type        = number
   description = "최소 노드 수 (자동 스케일링)"
-  default     = 1
+  default     = 4
 }
 
 variable "max_node_count" {
   type        = number
   description = "최대 노드 수 (자동 스케일링)"
-  default     = 5
+  default     = 6
 }
 
 variable "node_machine_type" {
@@ -261,4 +261,25 @@ variable "argo_rollouts_chart_version" {
   type        = string
   description = "Argo Rollouts Helm 차트 버전"
   default     = "2.31.1"
+}
+
+# =============================================================================
+# SSL/TLS 인증서 설정 변수 (GCP에서 직접 업로드한 인증서 참조)
+# =============================================================================
+variable "ssl_enabled" {
+  type        = bool
+  description = "SSL/TLS 인증서 사용 여부"
+  default     = true
+}
+
+variable "ssl_domain_name" {
+  type        = string
+  description = "SSL 인증서를 적용할 도메인 이름"
+  default     = "api.loventure.us"
+}
+
+variable "ssl_certificate_name" {
+  type        = string
+  description = "GCP에서 직접 업로드한 SSL 인증서 이름"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "gcp_region" {
 variable "gcp_zone" {
   type        = string
   description = "GCP 존"
-  default     = "asia-northeast3-a"
+  default     = "asia-northeast3-b"
 }
 
 variable "environment" {
@@ -281,5 +281,5 @@ variable "ssl_domain_name" {
 variable "ssl_certificate_name" {
   type        = string
   description = "GCP에서 직접 업로드한 SSL 인증서 이름"
-  default     = ""
+  default     = "pitterpetter-ssl"
 }


### PR DESCRIPTION
## 📝 목적/배경
- 마이크로서비스 아키텍처에 맞는 개별 인그레스 라우팅 구성 필요
- OAuth2 인증 플로우를 위한 전용 엔드포인트 설정 필요
- ArgoCD 접근을 위한 별도 도메인 및 경로 설정 필요
- 각 서비스별 헬스체크 및 모니터링 엔드포인트 구성
## 🔧 주요 작업(변경) 사항
- [x] Auth Service 전용 인그레스 구성 (`/oauth2`, `/api/auth`, `/api/onboarding`, `/api/users`)
- [x] Course Service 전용 인그레스 구성 (`/api/course`)
- [x] Content Service 전용 인그레스 구성 (`/api/diaries`)
- [x] ArgoCD 전용 인그레스 구성 (`argo.loventure.us` 도메인, `/argo` 베이스 패스)
- [x] OAuth2 Authorization 엔드포인트 라우팅 설정
- [x] SSL/TLS 설정 및 강제 리다이렉트 구성
- [x] 프록시 타임아웃 및 바디 사이즈 설정
- [x] GCP 존 설정 변경 (asia-northeast3-a → asia-northeast3-b)
- [x] SSL 인증서 설정 업데이트
## 🎥 스크린샷/데모 (선택)

## 🔗 이슈 연결
- PID-194

## ✅ 체크리스트
- [x] merge branch 가 develop 인지 확인
- [x] 모든 코드가 잘 작동하는지 확인
- [x] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타