### PR TITLE
[FEAT] Add Swagger UI endpoints for microservices - PIT-276

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -296,6 +296,32 @@ resource "kubernetes_ingress_v1" "auth_service_ingress" {
             }
           }
         }
+        # Swagger UI 경로
+        path {
+          path      = "/api/auth/swagger-ui"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-auth-service"
+              port {
+                number = 8081
+              }
+            }
+          }
+        }
+        # Swagger API Docs 경로
+        path {
+          path      = "/api/auth/v3/api-docs"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-auth-service"
+              port {
+                number = 8081
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -378,6 +404,32 @@ resource "kubernetes_ingress_v1" "course_service_ingress" {
             }
           }
         }
+        # Swagger UI 경로
+        path {
+          path      = "/api/course/swagger-ui"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-course-service"
+              port {
+                number = 8083
+              }
+            }
+          }
+        }
+        # Swagger API Docs 경로
+        path {
+          path      = "/api/course/v3/api-docs"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-course-service"
+              port {
+                number = 8083
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -450,6 +502,32 @@ resource "kubernetes_ingress_v1" "content_service_ingress" {
         # Content Actuator 경로
         path {
           path      = "/api/diaries/actuator"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-content-service"
+              port {
+                number = 8082
+              }
+            }
+          }
+        }
+        # Swagger UI 경로
+        path {
+          path      = "/api/diaries/swagger-ui"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "loventure-prod-content-service"
+              port {
+                number = 8082
+              }
+            }
+          }
+        }
+        # Swagger API Docs 경로
+        path {
+          path      = "/api/diaries/v3/api-docs"
           path_type = "Prefix"
           backend {
             service {


### PR DESCRIPTION
## 📝 목적/배경
API 문서화를 위한 Swagger UI 접근성 개선
각 마이크로서비스별 API 문서를 api.loventure.us에서 통합 관리
## 🔧 주요 작업(변경) 사항
[x] Auth Service: /api/auth/swagger-ui, /api/auth/v3/api-docs 경로 추가
[x] Course Service: /api/course/swagger-ui, /api/course/v3/api-docs 경로 추가
[x] Content Service: /api/diaries/swagger-ui, /api/diaries/v3/api-docs 경로 추가
[x] Nginx Ingress Controller 라우팅 설정 완료

## 🎥 스크린샷/데모 (선택)

## 🔗 이슈 연결
- PID-276

## ✅ 체크리스트
- [x] merge branch 가 develop 인지 확인
- [x] 모든 코드가 잘 작동하는지 확인
- [x] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타
로그인 후 Swagger UI 접근 가능 (인증 제외 설정 진행)
DNS 설정 업데이트 완료