### PR TITLE
[FEAT] Add Kibana ingress for external access - PIT-494

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -821,3 +821,64 @@ resource "kubernetes_ingress_v1" "argocd_ingress" {
   ]
 }
 
+# =============================================================================
+# Kibana 전용 Ingress (monitoring 네임스페이스)
+# -----------------------------------------------------------------------------
+# Kibana 대시보드 접근을 위한 전용 Ingress
+resource "kubernetes_ingress_v1" "kibana_ingress" {
+  count = var.ingress_nginx_enabled ? 1 : 0
+
+  metadata {
+    name      = "kibana-ingress"
+    namespace = "monitoring"
+    annotations = {
+      "nginx.ingress.kubernetes.io/ssl-redirect"   = "true"
+      "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true"
+      "nginx.ingress.kubernetes.io/backend-protocol" = "HTTP"
+      "nginx.ingress.kubernetes.io/proxy-body-size" = "10m"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout" = "300"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout" = "300"
+      "nginx.ingress.kubernetes.io/enable-cors" = "true"
+      "nginx.ingress.kubernetes.io/cors-allow-origin" = "https://kibana.loventure.us, https://api.loventure.us, https://loventure.us"
+      "nginx.ingress.kubernetes.io/cors-allow-methods" = "GET, POST, PUT, DELETE, OPTIONS"
+      "nginx.ingress.kubernetes.io/cors-allow-headers" = "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+      "nginx.ingress.kubernetes.io/cors-allow-credentials" = "true"
+    }
+  }
+
+  spec {
+    # Ingress Class 설정
+    ingress_class_name = "nginx"
+    
+    # SSL/TLS 설정
+    tls {
+      hosts = ["kibana.loventure.us"]
+      secret_name = var.ssl_enabled && var.ssl_certificate_name != "" ? data.google_compute_ssl_certificate.existing_cert[0].name : null
+    }
+
+    # Kibana 서버 규칙
+    rule {
+      host = "kibana.loventure.us"
+      http {
+        # 모든 경로 -> Kibana 서비스
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "kibana-kibana"
+              port {
+                number = 5601
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.ingress_nginx
+  ]
+}
+


### PR DESCRIPTION
## 📝 목적/배경
- Kibana 대시보드에 외부에서 접근할 수 없어서 모니터링 및 로그 분석이 어려움
- 이를 위한 외부 접근 설정 진행

## 🔧 주요 작업(변경) 사항
- [x] Kibana 전용 인그레스 설정 추가 (kibana.loventure.us)
- [x] SSL/TLS 인증서 적용
- [x] CORS 및 프록시 설정 구성

## 🎥 스크린샷/데모 (선택)

## 🔗 이슈 연결
- PID-494

## ✅ 체크리스트
- [x] merge branch 가 develop 인지 확인
- [x] 모든 코드가 잘 작동하는지 확인
- [x] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타